### PR TITLE
Bf/query index support

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,0 +1,10 @@
+name := "spark-dynamodb"
+scalaVersion := "2.11.8"
+
+libraryDependencies ++= Seq(
+  "com.amazonaws" % "aws-java-sdk-dynamodb" % "1.11.298",
+  "com.twitter" % "util-app_2.11" % "18.3.0",
+  "org.apache.spark" % "spark-sql_2.11" % "2.3.0" % "provided",
+  "org.scalatest" % "scalatest_2.11" % "3.0.5" % "test",
+  "com.google.guava" % "guava" % "14.0.1"
+)

--- a/src/main/scala/com/github/traviscrawford/spark/dynamodb/BaseScanner.scala
+++ b/src/main/scala/com/github/traviscrawford/spark/dynamodb/BaseScanner.scala
@@ -1,21 +1,16 @@
 package com.github.traviscrawford.spark.dynamodb
 
-import com.amazonaws.auth.AWSCredentials
-import com.amazonaws.auth.AWSCredentialsProvider
-import com.amazonaws.auth.AWSStaticCredentialsProvider
-import com.amazonaws.auth.BasicAWSCredentials
+import com.amazonaws.auth.{AWSCredentialsProvider, AWSStaticCredentialsProvider, BasicAWSCredentials}
 import com.amazonaws.client.builder.AwsClientBuilder.EndpointConfiguration
 import com.amazonaws.services.dynamodbv2.AmazonDynamoDBClientBuilder
-import com.amazonaws.services.dynamodbv2.document.DynamoDB
-import com.amazonaws.services.dynamodbv2.document.Table
-import com.amazonaws.services.dynamodbv2.document.spec.ScanSpec
+import com.amazonaws.services.dynamodbv2.document.{DynamoDB, Table}
+import com.amazonaws.services.dynamodbv2.document.spec.{QuerySpec, ScanSpec}
 import com.amazonaws.services.dynamodbv2.model.ReturnConsumedCapacity
 import com.amazonaws.services.dynamodbv2.xspec.ExpressionSpecBuilder
 import org.apache.spark.sql.types.StructType
 import org.slf4j.LoggerFactory
 
-import scala.collection.JavaConverters.mapAsJavaMapConverter
-import scala.collection.JavaConverters.mapAsScalaMapConverter
+import scala.collection.JavaConverters.{mapAsJavaMapConverter, mapAsScalaMapConverter}
 
 private[dynamodb] trait BaseScanner {
   private val log = LoggerFactory.getLogger(this.getClass)
@@ -55,7 +50,7 @@ private[dynamodb] trait BaseScanner {
     new DynamoDB(client).getTable(tableName)
   }
 
-  def getTable(config: ScanConfig): Table = {
+  def getTable(config: Config): Table = {
     getTable(
       tableName = config.table,
       config.maybeCredentials,
@@ -65,7 +60,7 @@ private[dynamodb] trait BaseScanner {
       config.maybeEndpoint)
   }
 
-  def getScanSpec(config: ScanConfig): ScanSpec = {
+  def getScanSpec(config: Config): ScanSpec = {
     val scanSpec = new ScanSpec()
       .withMaxPageSize(config.pageSize)
       .withReturnConsumedCapacity(ReturnConsumedCapacity.TOTAL)
@@ -99,10 +94,66 @@ private[dynamodb] trait BaseScanner {
 
     scanSpec
   }
+
+  def getQuerySpec(config: Config): QuerySpec = {
+    val querySpec = new QuerySpec()
+      .withMaxPageSize(config.pageSize)
+      .withReturnConsumedCapacity(ReturnConsumedCapacity.TOTAL)
+
+    // Queries might have required partition/hash keys
+    val partitionKey = parseStringToMap(config.maybePartitionKey)
+    val sortKey = parseStringToMap(config.maybeSortKey)
+
+    // Parse any projection expressions passed in
+    val exprSpecBuilder = config.maybeRequiredColumns
+      .map(requiredColumns => new ExpressionSpecBuilder().addProjections(requiredColumns: _*))
+    val parsedProjectionExpr = exprSpecBuilder.map(xSpecBuilder => xSpecBuilder.buildForScan())
+    val projectionNameMap = parsedProjectionExpr.flatMap(projExpr => Option(projExpr.getNameMap))
+      .map(_.asScala.toMap).getOrElse(Map.empty)
+    val projectionValueMap = parsedProjectionExpr.flatMap(projExpr => Option(projExpr.getValueMap))
+      .map(_.asScala.toMap).getOrElse(Map.empty)
+    parsedProjectionExpr.foreach(expr =>
+      querySpec.withProjectionExpression(expr.getProjectionExpression))
+
+    // Parse any filter expression passed in as an option
+    val parsedFilterExpr = config.maybeFilterExpression
+      .map(filterExpression => ParsedFilterExpression(filterExpression))
+    val filterNameMap = parsedFilterExpr.map(_.expressionNames).getOrElse(Map.empty)
+    val filterValueMap = parsedFilterExpr.map(_.expressionValues).getOrElse(Map.empty)
+    parsedFilterExpr.foreach(expr =>
+      querySpec.withFilterExpression(expr.expression))
+
+    // Parse/pass through any keyConditionExpression
+    if (config.maybeKeyConditionExpression.isDefined) {
+      querySpec.withKeyConditionExpression(config.maybeKeyConditionExpression.get)
+    }
+
+    // Combine parsed name and value maps from the projections and filter expressions
+    val nameMap = projectionNameMap ++ filterNameMap
+    Option(nameMap).filter(_.nonEmpty).foreach(nMap => querySpec.withNameMap(nMap.asJava))
+    val valueMap = projectionValueMap ++ filterValueMap ++ partitionKey ++ sortKey
+    Option(valueMap).filter(_.nonEmpty).foreach(vMap => querySpec.withValueMap(vMap.asJava))
+
+    querySpec
+  }
+
+    def parseStringToMap(s: Option[String]): Map[String, AnyRef] = {
+      s.map(_.split("=")).map(arr => arr(0) -> parseValue(arr(1)).asInstanceOf[AnyRef]).toMap
+    }
+
+    def parseValue(value: String): Any = {
+      try {
+        value.toInt
+      } catch {
+        case _ => value
+      }
+    }
 }
 
-private[dynamodb] case class ScanConfig(
+
+private[dynamodb] case class Config(
   table: String,
+  callType: String,
   segment: Int,
   totalSegments: Int,
   pageSize: Int,
@@ -114,6 +165,10 @@ private[dynamodb] case class ScanConfig(
   awsAccessKey: Option[String] = None,
   awsSecretKey: Option[String] = None,
   maybeRegion: Option[String] = None,
-  maybeEndpoint: Option[String] = None
+  maybeEndpoint: Option[String] = None,
+  maybePartitionKey: Option[String] = None,
+  maybeSortKey: Option[String] = None,
+  maybeKeyConditionExpression: Option[String] = None,
+  maybeIndexName: Option[String] = None
 )
 

--- a/src/main/scala/com/github/traviscrawford/spark/dynamodb/DefaultSource.scala
+++ b/src/main/scala/com/github/traviscrawford/spark/dynamodb/DefaultSource.scala
@@ -29,9 +29,26 @@ private[dynamodb] class DefaultSource
     val tableName = parameters.getOrElse("table",
       throw new IllegalArgumentException("Required parameter 'table' was unspecified.")
     )
+    val callType = parameters.getOrElse("calltype", "scan")
+
+    callType match {
+      case "query" | "index" => {
+        parameters.getOrElse("key_condition_expression",
+          throw new IllegalArgumentException(
+            "Required parameter 'key_condition_expression' was unspecified when using call type 'query'"
+          ))
+        parameters.getOrElse("partition_key",
+          throw new IllegalArgumentException(
+            "Required parameter 'partition_key' was unspecified when using call type 'query'"
+          ))
+      }
+      case _ => null
+    }
+
 
     DynamoDBRelation(
       tableName = tableName,
+      callType = callType,
       maybeFilterExpression = parameters.get("filter_expression"),
       maybePageSize = parameters.get("page_size"),
       maybeRegion = parameters.get("region"),
@@ -39,6 +56,11 @@ private[dynamodb] class DefaultSource
       maybeRateLimit = parameters.get("rate_limit_per_segment").map(Integer.parseInt),
       maybeSchema = maybeSchema,
       maybeCredentials = parameters.get("aws_credentials_provider"),
-      maybeEndpoint = parameters.get("endpoint"))(sqlContext)
+      maybeEndpoint = parameters.get("endpoint"),
+      maybePartitionKey = parameters.get("partition_key"),
+      maybeSortKey = parameters.get("sort_key"),
+      maybeKeyConditionExpression = parameters.get("key_condition_expression"),
+      maybeIndexName = parameters.get("index_name")
+    )(sqlContext)
   }
 }

--- a/src/main/scala/com/github/traviscrawford/spark/dynamodb/DynamoBackupJob.scala
+++ b/src/main/scala/com/github/traviscrawford/spark/dynamodb/DynamoBackupJob.scala
@@ -36,7 +36,7 @@ object DynamoBackupJob extends Job {
     val awsSecretKey = None
     if (overwrite()) deleteOutputPath(output())
 
-    DynamoScanner(sc, table(), totalSegments(), pageSize(),
+    DynamoScanner(sc, table(), totalSegments(), pageSize(), "scan",
       maybeCredentials, awsAccessKey, awsSecretKey, maybeRateLimit, maybeRegion).saveAsTextFile(output())
   }
 

--- a/src/main/scala/com/github/traviscrawford/spark/dynamodb/DynamoDBRelation.scala
+++ b/src/main/scala/com/github/traviscrawford/spark/dynamodb/DynamoDBRelation.scala
@@ -5,17 +5,15 @@ import java.util.concurrent.atomic.AtomicLong
 import com.amazonaws.services.dynamodbv2.document.spec.ScanSpec
 import com.google.common.util.concurrent.RateLimiter
 import org.apache.spark.rdd.RDD
-import org.apache.spark.sql.Row
-import org.apache.spark.sql.SQLContext
-import org.apache.spark.sql.sources.BaseRelation
-import org.apache.spark.sql.sources.PrunedScan
+import org.apache.spark.sql.{Row, SQLContext}
+import org.apache.spark.sql.sources.{BaseRelation, PrunedScan}
 import org.apache.spark.sql.types.StructType
 import org.slf4j.LoggerFactory
 
 import scala.collection.JavaConversions.asScalaIterator
 import scala.util.control.NonFatal
 
-/** Scan a DynamoDB table for use as a [[org.apache.spark.sql.DataFrame]].
+/** Scan/Query a DynamoDB table for use as a [[org.apache.spark.sql.DataFrame]].
   *
   * @param tableName        Name of the DynamoDB table to scan.
   * @param maybePageSize    DynamoDB request page size.
@@ -28,10 +26,12 @@ import scala.util.control.NonFatal
   *                         will be used, which, which will work for most users. If you have a
   *                         custom credentials provider it can be provided here.
   * @param maybeEndpoint    Endpoint to connect to DynamoDB on. This is intended for tests.
+  * @param maybeCallType    By default, a scan will be used, but potentially a user could define the use of a query.
   * @see http://docs.aws.amazon.com/amazondynamodb/latest/developerguide/QueryAndScanGuidelines.html
   */
 private[dynamodb] case class DynamoDBRelation(
   tableName: String,
+  callType: String,
   maybeFilterExpression: Option[String],
   maybePageSize: Option[String],
   maybeSegments: Option[String],
@@ -41,7 +41,11 @@ private[dynamodb] case class DynamoDBRelation(
   maybeCredentials: Option[String] = None,
   awsAccessKey: Option[String] = None,
   awsSecretKey: Option[String] = None,
-  maybeEndpoint: Option[String])
+  maybeEndpoint: Option[String],
+  maybeKeyConditionExpression: Option[String],
+  maybePartitionKey: Option[String],
+  maybeSortKey: Option[String],
+  maybeIndexName: Option[String])
   (@transient val sqlContext: SQLContext)
   extends BaseRelation with PrunedScan with BaseScanner {
 
@@ -75,22 +79,29 @@ private[dynamodb] case class DynamoDBRelation(
 
   override def buildScan(requiredColumns: Array[String]): RDD[Row] = {
     val segments = 0 until Segments
-    val scanConfigs = segments.map(idx => {
-      ScanConfig(
-        table = tableName,
-        segment = idx,
-        totalSegments = segments.length,
-        pageSize = pageSize,
-        maybeSchema = Some(schema),
-        maybeRequiredColumns = Some(requiredColumns),
-        maybeFilterExpression = maybeFilterExpression,
-        maybeRateLimit = maybeRateLimit,
-        maybeCredentials = maybeCredentials,
-        awsAccessKey = awsAccessKey,
-        awsSecretKey = awsSecretKey,
-        maybeRegion = maybeRegion,
-        maybeEndpoint = maybeEndpoint)
-    })
+
+    val config = segments.map(idx => {
+        Config(
+          table = tableName,
+          callType = callType,
+          segment = idx,
+          totalSegments = segments.length,
+          pageSize = pageSize,
+          maybeSchema = Some(schema),
+          maybeRequiredColumns = Some(requiredColumns),
+          maybeFilterExpression = maybeFilterExpression,
+          maybeRateLimit = maybeRateLimit,
+          maybeCredentials = maybeCredentials,
+          awsAccessKey = awsAccessKey,
+          awsSecretKey = awsSecretKey,
+          maybeRegion = maybeRegion,
+          maybeEndpoint = maybeEndpoint,
+          maybeKeyConditionExpression = maybeKeyConditionExpression,
+          maybePartitionKey = maybePartitionKey,
+          maybeSortKey = maybeSortKey,
+          maybeIndexName = maybeIndexName
+        )
+      })
 
     val tableDesc = Table.describe()
 
@@ -98,16 +109,23 @@ private[dynamodb] case class DynamoDBRelation(
       s"using ${tableDesc.getTableSizeBytes} bytes.")
 
     log.info(s"Schema for tableName ${tableDesc.getTableName}: $schema")
-
-    sqlContext.sparkContext
-      .parallelize(scanConfigs, scanConfigs.length)
-      .flatMap(scan)
+    if (callType == "scan") {
+      sqlContext.sparkContext
+        .parallelize(config, config.length)
+        .flatMap(scan)
+    }
+    else {
+      sqlContext.sparkContext
+        .parallelize(config, config.length)
+        .flatMap(query)
+    }
   }
 
-  def scan(config: ScanConfig): Iterator[Row] = {
-    val scanSpec = getScanSpec(config)
+  def scan(config: Config): Iterator[Row] = {
     val table = getTable(config)
+    val scanSpec = getScanSpec(config)
     val result = table.scan(scanSpec)
+
     val failureCounter = new AtomicLong()
 
     val maybeRateLimiter = config.maybeRateLimit.map(rateLimit => {
@@ -135,6 +153,57 @@ private[dynamodb] case class DynamoDBRelation(
       maybeRateLimiter.foreach(rateLimiter => {
         // DynamoDBLocal.jar does not implement consumed capacity
         val maybeConsumedCapacityUnits = Option(page.getLowLevelResult.getScanResult.getConsumedCapacity)
+            .map(_.getCapacityUnits)
+            .map(math.ceil(_).toInt)
+
+        maybeConsumedCapacityUnits.foreach(consumedCapacityUnits => {
+          rateLimiter.acquire(consumedCapacityUnits)
+        })
+      })
+
+      rows
+    })
+  }
+
+  def query(config: Config): Iterator[Row] = {
+    val table = getTable(config)
+    val result = if (callType == "query") {
+      val querySpec = getQuerySpec(config)
+      table.query(querySpec)
+    }
+    else {
+      val querySpec = getQuerySpec(config)
+      val index = table.getIndex(config.maybeIndexName.get)
+      index.query(querySpec)
+    }
+
+    val failureCounter = new AtomicLong()
+
+    val maybeRateLimiter = config.maybeRateLimit.map(rateLimit => {
+      log.info(s"Segment ${config.segment} using rate limit of $rateLimit")
+      RateLimiter.create(rateLimit)
+    })
+
+    // Each `pages.next` call results in a DynamoDB network call.
+    result.pages().iterator().flatMap(page => {
+      // This result set resides in local memory.
+      val rows = page.iterator().flatMap(item => {
+        try {
+          Some(ItemConverter.toRow(item, config.maybeSchema.get))
+        } catch {
+          case NonFatal(err) =>
+            // Log some example conversion failures but do not spam the logs.
+            if (failureCounter.incrementAndGet() < 3) {
+              log.error(s"Failed converting item to row: ${item.toJSON}", err)
+            }
+            None
+        }
+      })
+
+      // Blocks until rate limit is available.
+      maybeRateLimiter.foreach(rateLimiter => {
+        // DynamoDBLocal.jar does not implement consumed capacity
+        val maybeConsumedCapacityUnits = Option(page.getLowLevelResult.getQueryResult.getConsumedCapacity)
           .map(_.getCapacityUnits)
           .map(math.ceil(_).toInt)
 

--- a/src/main/scala/com/github/traviscrawford/spark/dynamodb/DynamoScanner.scala
+++ b/src/main/scala/com/github/traviscrawford/spark/dynamodb/DynamoScanner.scala
@@ -22,6 +22,7 @@ object DynamoScanner extends BaseScanner {
     table: String,
     totalSegments: Int,
     pageSize: Int,
+    callType: String,
     maybeCredentials: Option[String] = None,
     awsAccessKey: Option[String] = None,
     awsSecretKey: Option[String] = None,
@@ -32,8 +33,9 @@ object DynamoScanner extends BaseScanner {
 
     val segments = 0 until totalSegments
     val scanConfigs = segments.map(idx => {
-      ScanConfig(
+      Config(
         table = table,
+        callType = callType,
         segment = idx,
         totalSegments = segments.length,
         pageSize = pageSize,
@@ -48,7 +50,7 @@ object DynamoScanner extends BaseScanner {
     sc.parallelize(scanConfigs, scanConfigs.length).flatMap(scan)
   }
 
-  private def scan(config: ScanConfig): Iterator[String] = {
+  private def scan(config: Config): Iterator[String] = {
     val maybeRateLimiter = config.maybeRateLimit.map(rateLimit => {
       log.info(s"Segment ${config.segment} using rate limit of $rateLimit")
       RateLimiter.create(rateLimit)

--- a/src/main/scala/com/github/traviscrawford/spark/dynamodb/ParsedFilterExpression.scala
+++ b/src/main/scala/com/github/traviscrawford/spark/dynamodb/ParsedFilterExpression.scala
@@ -11,8 +11,8 @@ package com.github.traviscrawford.spark.dynamodb
 private object ParsedFilterExpression {
 
   private val CompareLongExpr = """(\w+) (=|>|<|>=|<=|<>) (\d+)""".r
-  private val CompareStringExpr = """(\w+) (=|>|<|>=|<=|<>) (\D+)""".r
-  private val BeginsWithExpr = """begins_with\((\w+), (\D+)\)""".r
+  private val CompareStringExpr = """(\w+) (=|>|<|>=|<=|<>) (\w+)""".r
+  private val BeginsWithExpr = """begins_with\((\w+), (\w+)\)""".r
 
   def apply(filterExpression: String): ParsedFilterExpression = {
     filterExpression match {

--- a/src/test/scala/com/github/traviscrawford/spark/dynamodb/DynamoScannerIntegrationSpec.scala
+++ b/src/test/scala/com/github/traviscrawford/spark/dynamodb/DynamoScannerIntegrationSpec.scala
@@ -6,6 +6,7 @@ class DynamoScannerIntegrationSpec extends BaseIntegrationSpec {
       table = TestUsersTableName,
       totalSegments = 1,
       pageSize = 1000,
+      callType = "scan",
       maybeRateLimit = None,
       maybeEndpoint = Some(LocalDynamoDBEndpoint))
 


### PR DESCRIPTION
Adding queries against the main table and queries against secondary indexes support.

Examples of how to use:
```
// Query against the main table with only the partition key
    val df = spark.read
      .option("key_condition_expression", "partitionKeyName = :PartitionKeyVarName")
      .option("partition_key", ":PartitionKeyVarName=PartitionKeyValue")
      .option("calltype", "query")
      .option("region", "us-east-1")
      .dynamodb("TableName)
   
// Query against the main table, partition key, and sort key
    val df = spark.read
      .option("segments", 1) // optional
      .option("key_condition_expression", "partitionKeyName = :PartitionKeyVarName and  rangeKeyName = :RangeKeyVarName")
      .option("partition_key", ":PartitionKeyVarName=PartitionKeyValue")
      .option("sort_key", ":RangeKeyVarName=RangeKeyValue")
      .option("calltype", "query")
      .option("region", "us-east-1")
      .dynamodb("TableName)

// Queries against an index
    val df = spark.read
      .schema(PreSuppliedSchemaObject) // can also be inferred, this is optional
      .option("key_condition_expression", "partitionKeyName = :PartitionKeyVarName and  rangeKeyName = :RangeKeyVarName")
      .option("partition_key", ":PartitionKeyVarName=PartitionKeyValue")
      .option("sort_key", ":RangeKeyVarName=RangeKeyValue")
      .option("calltype", "index")
      .option("index_name", "NameOfIndex")
      .option("region", "us-east-1")
      .dynamodb("TableName)
```